### PR TITLE
client_runner: yield to the event loop

### DIFF
--- a/conformance/client_runner.py
+++ b/conformance/client_runner.py
@@ -415,8 +415,6 @@ async def handle_message(msg: client_compat_pb2.ClientCompatRequest) -> client_c
 
 
 if __name__ == "__main__":
-    if "--debug" in sys.argv:
-        logging.debug("Debug mode enabled")
 
     async def run_message(req: client_compat_pb2.ClientCompatRequest) -> None:
         """Run the message handler for a given request."""
@@ -435,5 +433,6 @@ if __name__ == "__main__":
         loop = asyncio.get_event_loop()
         while req := await loop.run_in_executor(None, read_request):
             loop.create_task(run_message(req))
+            await asyncio.sleep(0)
 
     asyncio.run(read_requests())


### PR DESCRIPTION
This pull request makes minor adjustments to the `conformance/client_runner.py` file by removing unnecessary debug logging and improving the handling of asynchronous tasks in the `read_requests` function.

Code cleanup:

* Removed the debug logging block that checked for the `--debug` argument, as it was unused and unnecessary. (`[conformance/client_runner.pyL418-L419](diffhunk://#diff-f622a5ba36418f0d9feaef268242d164a070e854612c0a4705f6260e7e5e722bL418-L419)`)

Asynchronous task handling:

* Added a `await asyncio.sleep(0)` statement in the `read_requests` function to yield control back to the event loop, ensuring better task scheduling and responsiveness. (`[conformance/client_runner.pyR436](diffhunk://#diff-f622a5ba36418f0d9feaef268242d164a070e854612c0a4705f6260e7e5e722bR436)`)