### PR TITLE
conformance: remove try-except blocks from server impl

### DIFF
--- a/conformance/run-testcase.txt
+++ b/conformance/run-testcase.txt
@@ -1,1 +1,0 @@
-Duplicate Metadata/HTTPVersion:1/Protocol:PROTOCOL_GRPC_WEB/Codec:CODEC_PROTO/Compression:COMPRESSION_IDENTITY/TLS:false/(grpc server impl)/bidi-stream/half-duplex/error-with-responses

--- a/conformance/server.py
+++ b/conformance/server.py
@@ -123,61 +123,54 @@ class ConformanceService(ConformanceServiceHandler):
             - Returns the constructed response or raises the error if defined.
 
         """
-        try:
-            response_definition = request.message.response_definition
+        response_definition = request.message.response_definition
 
-            request_any = any_pb2.Any()
-            request_any.Pack(request.message)
+        request_any = any_pb2.Any()
+        request_any.Pack(request.message)
 
-            request_info = service_pb2.ConformancePayload.RequestInfo(
-                request_headers=pb_headers_from_headers(request.headers),
-                requests=[request_any],
-                timeout_ms=int(request.timeout) if request.timeout else None,
-                connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
-                    query_params=pb_query_params_from_peer_query(request.peer.query),
-                ),
+        request_info = service_pb2.ConformancePayload.RequestInfo(
+            request_headers=pb_headers_from_headers(request.headers),
+            requests=[request_any],
+            timeout_ms=int(request.timeout) if request.timeout else None,
+            connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
+                query_params=pb_query_params_from_peer_query(request.peer.query),
+            ),
+        )
+
+        error = None
+        if response_definition.HasField("error"):
+            detail = any_pb2.Any()
+            detail.Pack(request_info)
+            response_definition.error.details.append(detail)
+
+            headers = headers_from_pb_headers(response_definition.response_headers)
+            trailers = headers_from_pb_headers(response_definition.response_trailers)
+
+            metadata = Headers()
+            metadata.update(headers)
+            metadata.update(trailers)
+
+            error = ConnectError(
+                message=response_definition.error.message,
+                code=code_from_pb_code(response_definition.error.code),
+                details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
+                metadata=metadata,
+            )
+        else:
+            payload = service_pb2.ConformancePayload(
+                data=response_definition.response_data,
+                request_info=request_info,
             )
 
-            error = None
-            if response_definition.HasField("error"):
-                detail = any_pb2.Any()
-                detail.Pack(request_info)
-                response_definition.error.details.append(detail)
-
+            if response_definition:
                 headers = headers_from_pb_headers(response_definition.response_headers)
                 trailers = headers_from_pb_headers(response_definition.response_trailers)
 
-                metadata = Headers()
-                metadata.update(headers)
-                metadata.update(trailers)
+        if response_definition.response_delay_ms:
+            await asyncio.sleep(response_definition.response_delay_ms / 1000)
 
-                error = ConnectError(
-                    message=response_definition.error.message,
-                    code=code_from_pb_code(response_definition.error.code),
-                    details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
-                    metadata=metadata,
-                )
-            else:
-                payload = service_pb2.ConformancePayload(
-                    data=response_definition.response_data,
-                    request_info=request_info,
-                )
-
-                if response_definition:
-                    headers = headers_from_pb_headers(response_definition.response_headers)
-                    trailers = headers_from_pb_headers(response_definition.response_trailers)
-
-            if response_definition.response_delay_ms:
-                await asyncio.sleep(response_definition.response_delay_ms / 1000)
-
-            if error:
-                raise error
-
-        except ConnectError:
-            raise
-
-        except Exception:
-            raise
+        if error:
+            raise error
 
         return UnaryResponse(content=service_pb2.UnaryResponse(payload=payload), headers=headers, trailers=trailers)
 
@@ -204,61 +197,54 @@ class ConformanceService(ConformanceServiceHandler):
             Exception: For any other unexpected errors.
 
         """
-        try:
-            response_definition = request.message.response_definition
+        response_definition = request.message.response_definition
 
-            request_any = any_pb2.Any()
-            request_any.Pack(request.message)
+        request_any = any_pb2.Any()
+        request_any.Pack(request.message)
 
-            request_info = service_pb2.ConformancePayload.RequestInfo(
-                request_headers=pb_headers_from_headers(request.headers),
-                requests=[request_any],
-                timeout_ms=int(request.timeout) if request.timeout else None,
-                connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
-                    query_params=pb_query_params_from_peer_query(request.peer.query),
-                ),
+        request_info = service_pb2.ConformancePayload.RequestInfo(
+            request_headers=pb_headers_from_headers(request.headers),
+            requests=[request_any],
+            timeout_ms=int(request.timeout) if request.timeout else None,
+            connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
+                query_params=pb_query_params_from_peer_query(request.peer.query),
+            ),
+        )
+
+        error = None
+        if response_definition.HasField("error"):
+            detail = any_pb2.Any()
+            detail.Pack(request_info)
+            response_definition.error.details.append(detail)
+
+            headers = headers_from_pb_headers(response_definition.response_headers)
+            trailers = headers_from_pb_headers(response_definition.response_trailers)
+
+            metadata = Headers()
+            metadata.update(headers)
+            metadata.update(trailers)
+
+            error = ConnectError(
+                message=response_definition.error.message,
+                code=code_from_pb_code(response_definition.error.code),
+                details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
+                metadata=metadata,
+            )
+        else:
+            payload = service_pb2.ConformancePayload(
+                data=response_definition.response_data,
+                request_info=request_info,
             )
 
-            error = None
-            if response_definition.HasField("error"):
-                detail = any_pb2.Any()
-                detail.Pack(request_info)
-                response_definition.error.details.append(detail)
-
+            if response_definition:
                 headers = headers_from_pb_headers(response_definition.response_headers)
                 trailers = headers_from_pb_headers(response_definition.response_trailers)
 
-                metadata = Headers()
-                metadata.update(headers)
-                metadata.update(trailers)
+        if response_definition.response_delay_ms:
+            await asyncio.sleep(response_definition.response_delay_ms / 1000)
 
-                error = ConnectError(
-                    message=response_definition.error.message,
-                    code=code_from_pb_code(response_definition.error.code),
-                    details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
-                    metadata=metadata,
-                )
-            else:
-                payload = service_pb2.ConformancePayload(
-                    data=response_definition.response_data,
-                    request_info=request_info,
-                )
-
-                if response_definition:
-                    headers = headers_from_pb_headers(response_definition.response_headers)
-                    trailers = headers_from_pb_headers(response_definition.response_trailers)
-
-            if response_definition.response_delay_ms:
-                await asyncio.sleep(response_definition.response_delay_ms / 1000)
-
-            if error:
-                raise error
-
-        except ConnectError:
-            raise
-
-        except Exception:
-            raise
+        if error:
+            raise error
 
         return UnaryResponse(
             content=service_pb2.IdempotentUnaryResponse(payload=payload), headers=headers, trailers=trailers
@@ -293,65 +279,58 @@ class ConformanceService(ConformanceServiceHandler):
         response_definition = None
         messages = []
 
-        try:
-            async for message in request.messages:
-                if response_definition is None:
-                    response_definition = message.response_definition
+        async for message in request.messages:
+            if response_definition is None:
+                response_definition = message.response_definition
 
-                message_any = any_pb2.Any()
-                message_any.Pack(message)
-                messages.append(message_any)
+            message_any = any_pb2.Any()
+            message_any.Pack(message)
+            messages.append(message_any)
 
-            request_info = service_pb2.ConformancePayload.RequestInfo(
-                request_headers=pb_headers_from_headers(request.headers),
-                requests=messages,
-                timeout_ms=int(request.timeout) if request.timeout else None,
-                connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
-                    query_params=pb_query_params_from_peer_query(request.peer.query),
-                ),
+        request_info = service_pb2.ConformancePayload.RequestInfo(
+            request_headers=pb_headers_from_headers(request.headers),
+            requests=messages,
+            timeout_ms=int(request.timeout) if request.timeout else None,
+            connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
+                query_params=pb_query_params_from_peer_query(request.peer.query),
+            ),
+        )
+
+        error = None
+        payload = None
+        if response_definition and response_definition.HasField("error"):
+            detail = any_pb2.Any()
+            detail.Pack(request_info)
+            response_definition.error.details.append(detail)
+
+            headers = headers_from_pb_headers(response_definition.response_headers)
+            trailers = headers_from_pb_headers(response_definition.response_trailers)
+
+            metadata = Headers()
+            metadata.update(headers)
+            metadata.update(trailers)
+
+            error = ConnectError(
+                message=response_definition.error.message,
+                code=code_from_pb_code(response_definition.error.code),
+                details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
+                metadata=metadata,
+            )
+        else:
+            payload = service_pb2.ConformancePayload(
+                request_info=request_info,
             )
 
-            error = None
-            payload = None
-            if response_definition and response_definition.HasField("error"):
-                detail = any_pb2.Any()
-                detail.Pack(request_info)
-                response_definition.error.details.append(detail)
-
+            if response_definition:
+                payload.data = response_definition.response_data
                 headers = headers_from_pb_headers(response_definition.response_headers)
                 trailers = headers_from_pb_headers(response_definition.response_trailers)
 
-                metadata = Headers()
-                metadata.update(headers)
-                metadata.update(trailers)
+            if response_definition and response_definition.response_delay_ms:
+                await asyncio.sleep(response_definition.response_delay_ms / 1000)
 
-                error = ConnectError(
-                    message=response_definition.error.message,
-                    code=code_from_pb_code(response_definition.error.code),
-                    details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
-                    metadata=metadata,
-                )
-            else:
-                payload = service_pb2.ConformancePayload(
-                    request_info=request_info,
-                )
-
-                if response_definition:
-                    payload.data = response_definition.response_data
-                    headers = headers_from_pb_headers(response_definition.response_headers)
-                    trailers = headers_from_pb_headers(response_definition.response_trailers)
-
-                if response_definition and response_definition.response_delay_ms:
-                    await asyncio.sleep(response_definition.response_delay_ms / 1000)
-
-            if error:
-                raise error
-
-        except ConnectError:
-            raise
-
-        except Exception:
-            raise
+        if error:
+            raise error
 
         return StreamResponse(
             content=service_pb2.ClientStreamResponse(payload=payload),
@@ -386,82 +365,75 @@ class ConformanceService(ConformanceServiceHandler):
         response_definition = None
         messages = []
 
-        try:
-            async for message in request.messages:
-                if response_definition is None:
-                    response_definition = message.response_definition
+        async for message in request.messages:
+            if response_definition is None:
+                response_definition = message.response_definition
 
-                message_any = any_pb2.Any()
-                message_any.Pack(message)
-                messages.append(message_any)
+            message_any = any_pb2.Any()
+            message_any.Pack(message)
+            messages.append(message_any)
 
-            headers = None
-            trailers = None
-            if response_definition:
+        headers = None
+        trailers = None
+        if response_definition:
+            headers = headers_from_pb_headers(response_definition.response_headers)
+            trailers = headers_from_pb_headers(response_definition.response_trailers)
+
+        request_info = service_pb2.ConformancePayload.RequestInfo(
+            request_headers=pb_headers_from_headers(request.headers),
+            requests=messages,
+            timeout_ms=int(request.timeout) if request.timeout else None,
+            connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
+                query_params=pb_query_params_from_peer_query(request.peer.query),
+            ),
+        )
+
+        async def iterator() -> typing.AsyncIterator[service_pb2.ServerStreamResponse]:
+            first_response = True
+
+            if response_definition is None:
+                return
+
+            for response_data in response_definition.response_data:
+                if first_response:
+                    payload = service_pb2.ConformancePayload(
+                        data=response_data,
+                        request_info=request_info,
+                    )
+                    first_response = False
+                else:
+                    payload = service_pb2.ConformancePayload(
+                        data=response_data,
+                    )
+
+                if response_definition.response_delay_ms:
+                    await asyncio.sleep(response_definition.response_delay_ms / 1000)
+
+                yield service_pb2.ServerStreamResponse(
+                    payload=payload,
+                )
+
+            if response_definition.HasField("error"):
                 headers = headers_from_pb_headers(response_definition.response_headers)
                 trailers = headers_from_pb_headers(response_definition.response_trailers)
 
-            request_info = service_pb2.ConformancePayload.RequestInfo(
-                request_headers=pb_headers_from_headers(request.headers),
-                requests=messages,
-                timeout_ms=int(request.timeout) if request.timeout else None,
-                connect_get_info=service_pb2.ConformancePayload.ConnectGetInfo(
-                    query_params=pb_query_params_from_peer_query(request.peer.query),
-                ),
-            )
+                metadata = Headers()
+                metadata.update(headers)
+                metadata.update(trailers)
 
-            async def iterator() -> typing.AsyncIterator[service_pb2.ServerStreamResponse]:
-                first_response = True
+                if first_response:
+                    detail = any_pb2.Any()
+                    detail.Pack(request_info)
+                    response_definition.error.details.append(detail)
 
-                if response_definition is None:
-                    return
+                error = ConnectError(
+                    message=response_definition.error.message,
+                    code=code_from_pb_code(response_definition.error.code),
+                    details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
+                    metadata=metadata,
+                )
 
-                for response_data in response_definition.response_data:
-                    if first_response:
-                        payload = service_pb2.ConformancePayload(
-                            data=response_data,
-                            request_info=request_info,
-                        )
-                        first_response = False
-                    else:
-                        payload = service_pb2.ConformancePayload(
-                            data=response_data,
-                        )
-
-                    if response_definition.response_delay_ms:
-                        await asyncio.sleep(response_definition.response_delay_ms / 1000)
-
-                    yield service_pb2.ServerStreamResponse(
-                        payload=payload,
-                    )
-
-                if response_definition.HasField("error"):
-                    headers = headers_from_pb_headers(response_definition.response_headers)
-                    trailers = headers_from_pb_headers(response_definition.response_trailers)
-
-                    metadata = Headers()
-                    metadata.update(headers)
-                    metadata.update(trailers)
-
-                    if first_response:
-                        detail = any_pb2.Any()
-                        detail.Pack(request_info)
-                        response_definition.error.details.append(detail)
-
-                    error = ConnectError(
-                        message=response_definition.error.message,
-                        code=code_from_pb_code(response_definition.error.code),
-                        details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
-                        metadata=metadata,
-                    )
-
-                    raise error
-
-        except ConnectError:
-            raise
-
-        except Exception:
-            raise
+                raise error
 
         return StreamResponse(
             content=iterator(),
@@ -503,78 +475,71 @@ class ConformanceService(ConformanceServiceHandler):
         first_response = True
         response_index = 0
 
-        try:
-            async for message in request.messages:
-                message_any = any_pb2.Any()
-                message_any.Pack(message)
-                messages.append(message_any)
+        async for message in request.messages:
+            message_any = any_pb2.Any()
+            message_any.Pack(message)
+            messages.append(message_any)
 
-                if first_response:
-                    response_definition = message.response_definition
-                    first_response = False
+            if first_response:
+                response_definition = message.response_definition
+                first_response = False
 
-                    if response_definition:
-                        headers = headers_from_pb_headers(response_definition.response_headers)
-                        trailers = headers_from_pb_headers(response_definition.response_trailers)
-
-            async def iterator() -> typing.AsyncIterator[service_pb2.BidiStreamResponse]:
-                nonlocal response_index
-
-                while response_definition and response_index < len(response_definition.response_data):
-                    if response_index == 0:
-                        request_info = service_pb2.ConformancePayload.RequestInfo(
-                            request_headers=pb_headers_from_headers(request.headers),
-                            requests=messages,
-                            timeout_ms=int(request.timeout) if request.timeout else None,
-                        )
-                    else:
-                        request_info = None
-
-                    response = service_pb2.BidiStreamResponse(
-                        payload=service_pb2.ConformancePayload(
-                            request_info=request_info,
-                            data=response_definition.response_data[response_index],
-                        )
-                    )
-                    if response_definition.response_delay_ms:
-                        await asyncio.sleep(response_definition.response_delay_ms / 1000)
-
-                    response_index += 1
-                    yield response
-
-                if response_definition and response_definition.HasField("error"):
+                if response_definition:
                     headers = headers_from_pb_headers(response_definition.response_headers)
                     trailers = headers_from_pb_headers(response_definition.response_trailers)
 
-                    metadata = Headers()
-                    metadata.update(headers)
-                    metadata.update(trailers)
+        async def iterator() -> typing.AsyncIterator[service_pb2.BidiStreamResponse]:
+            nonlocal response_index
 
-                    if response_index == 0:
-                        request_info = service_pb2.ConformancePayload.RequestInfo(
-                            request_headers=pb_headers_from_headers(request.headers),
-                            requests=messages,
-                            timeout_ms=int(request.timeout) if request.timeout else None,
-                        )
+            while response_definition and response_index < len(response_definition.response_data):
+                if response_index == 0:
+                    request_info = service_pb2.ConformancePayload.RequestInfo(
+                        request_headers=pb_headers_from_headers(request.headers),
+                        requests=messages,
+                        timeout_ms=int(request.timeout) if request.timeout else None,
+                    )
+                else:
+                    request_info = None
 
-                        detail = any_pb2.Any()
-                        detail.Pack(request_info)
-                        response_definition.error.details.append(detail)
+                response = service_pb2.BidiStreamResponse(
+                    payload=service_pb2.ConformancePayload(
+                        request_info=request_info,
+                        data=response_definition.response_data[response_index],
+                    )
+                )
+                if response_definition.response_delay_ms:
+                    await asyncio.sleep(response_definition.response_delay_ms / 1000)
 
-                    error = ConnectError(
-                        message=response_definition.error.message,
-                        code=code_from_pb_code(response_definition.error.code),
-                        details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
-                        metadata=metadata,
+                response_index += 1
+                yield response
+
+            if response_definition and response_definition.HasField("error"):
+                headers = headers_from_pb_headers(response_definition.response_headers)
+                trailers = headers_from_pb_headers(response_definition.response_trailers)
+
+                metadata = Headers()
+                metadata.update(headers)
+                metadata.update(trailers)
+
+                if response_index == 0:
+                    request_info = service_pb2.ConformancePayload.RequestInfo(
+                        request_headers=pb_headers_from_headers(request.headers),
+                        requests=messages,
+                        timeout_ms=int(request.timeout) if request.timeout else None,
                     )
 
-                    raise error
+                    detail = any_pb2.Any()
+                    detail.Pack(request_info)
+                    response_definition.error.details.append(detail)
 
-        except ConnectError:
-            raise
+                error = ConnectError(
+                    message=response_definition.error.message,
+                    code=code_from_pb_code(response_definition.error.code),
+                    details=[ErrorDetail(pb_any=error) for error in response_definition.error.details],
+                    metadata=metadata,
+                )
 
-        except Exception:
-            raise
+                raise error
 
         return StreamResponse(
             content=iterator(),

--- a/conformance/server_known_failing.yaml
+++ b/conformance/server_known_failing.yaml
@@ -1,1 +1,0 @@
-Deadline Propagation/**

--- a/conformance/server_runner.py
+++ b/conformance/server_runner.py
@@ -21,15 +21,13 @@ from gen.connectrpc.conformance.v1 import config_pb2
 from gen.connectrpc.conformance.v1.server_compat_pb2 import ServerCompatRequest, ServerCompatResponse
 from server import app
 
-logger = logging.getLogger("conformance.runner")
-
-# Setup logging
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     handlers=[logging.FileHandler("conformance_server.log"), logging.StreamHandler()],
 )
-logger = logging.getLogger(__name__)
+
+logger = logging.getLogger("conformance.runner")
 
 
 def find_free_port() -> int:


### PR DESCRIPTION
This pull request primarily focuses on simplifying error handling in the `conformance/server.py` file by removing redundant `try-except` blocks, alongside a few other minor updates to improve maintainability and clean up unused configurations.

### Error handling simplification in `conformance/server.py`:

* Removed redundant `try-except` blocks for `ConnectError` and generic exceptions in multiple asynchronous methods, including `Unary`, `IdempotentUnary`, `ClientStream`, `ServerStream`, and `BidiStream`. This change assumes that unhandled exceptions will propagate naturally, simplifying the code and reducing unnecessary boilerplate. [[1]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L126) [[2]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L176-L181) [[3]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L207) [[4]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L257-L262) [[5]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L296) [[6]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L350-L355) [[7]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L389) [[8]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L460-L465) [[9]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L506) [[10]](diffhunk://#diff-961f4b67c80e0c08297fc2de22fc1a5a8523c524eeac19343e28064f179392c5L573-L578)

### Configuration and logging cleanup:

* Removed the duplicate metadata test case entry from `conformance/run-testcase.txt` to avoid redundancy.
* Removed the unused "Deadline Propagation" configuration from `conformance/server_known_failing.yaml`.
* Refactored logging setup in `conformance/server_runner.py` to streamline logger initialization and ensure consistent logging behavior.