### PR TITLE
github: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# KEEP THIS FILE SORTED. Order is important. Last match takes precedence.
+
+* @tsubakiky @zchee
+
+cmd/protoc-gen-connect-python @zchee


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to define ownership for specific files and directories. The changes ensure proper assignment of code ownership and clarify responsibilities.

Ownership assignments:

* Added a general ownership rule for all files (`*`) and assigned it to `@tsubakiky` and `@zchee`.
* Assigned ownership of the `cmd/protoc-gen-connect-python` directory specifically to `@zchee`.