### PR TITLE
github/workflows: add conformance test

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -95,4 +95,5 @@ jobs:
 
       - name: Run the connectconformance for client
         run: |
-          connectconformance --trace --vv --conf ./client_config.yaml --mode client -- uv run python client_runner.py
+          connectconformance --trace --conf ./client_config.yaml --mode client --known-flaky @./client_known_flaky.yaml -- uv run python client_runner.py
+

--- a/conformance/client_known_flaky.yaml
+++ b/conformance/client_known_flaky.yaml
@@ -1,0 +1,1 @@
+Client Cancellation/**


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate conformance testing for both server and client modes. It also includes configuration updates to handle known flaky tests for the client.

### New GitHub Actions Workflow for Conformance Testing:

* `.github/workflows/conformance.yaml`: Added a new workflow named "Conformance" to run conformance tests on `push`, `pull_request`, and manual triggers. The workflow includes two jobs:
  - **Server job**: Sets up Python, Go, and `uv`, installs the project, and runs the `connectconformance` tool in server mode.
  - **Client job**: Similar to the server job but runs the `connectconformance` tool in client mode with additional handling for known flaky tests.

### Configuration for Known Flaky Tests:

* [`conformance/client_known_flaky.yaml`](diffhunk://#diff-3a0227a39dc1a90b33fca0f32c14d3c730940e4e1903cdbe59aa5847b7ea9d37R1): Added a configuration file to specify known flaky tests for the client, starting with the `Client Cancellation/**` test case.