### PR TITLE
protocol_grpc: small fix

### DIFF
--- a/src/connect/protocol_connect/connect_handler.py
+++ b/src/connect/protocol_connect/connect_handler.py
@@ -207,7 +207,7 @@ class ConnectHandler(ProtocolHandler):
             )
 
         peer = Peer(
-            address=Address(host=request.client.host, port=request.client.port) if request.client else request.client,
+            address=Address(host=request.client.host, port=request.client.port) if request.client else None,
             protocol=PROTOCOL_CONNECT,
             query=request.query_params,
         )

--- a/src/connect/protocol_grpc/constants.py
+++ b/src/connect/protocol_grpc/constants.py
@@ -21,8 +21,8 @@ GRPC_WEB_CONTENT_TYPE_PREFIX = GRPC_WEB_CONTENT_TYPE_DEFAULT + "+"
 HEADER_X_USER_AGENT = "X-User-Agent"
 
 GRPC_ALLOWED_METHODS = [HTTPMethod.POST]
-
-DEFAULT_GRPC_USER_AGENT = f"connect-python/{__version__} (Python/{__version__})"
+_python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+DEFAULT_GRPC_USER_AGENT = f"connect-python/{__version__} (Python/{_python_version})"
 
 RE_TIMEOUT = re.compile(r"^(\d{1,8})([HMSmun])$")
 
@@ -35,4 +35,6 @@ UNIT_TO_SECONDS = {
     "H": 3600.0,
 }
 
+GRPC_TIMEOUT_MAX_VALUE = 10**8
+GRPC_TIMEOUT_MAX_DURATION = 99_999_999
 MAX_HOURS = sys.maxsize // (60 * 60 * 1_000_000_000)

--- a/src/connect/protocol_grpc/error_trailer.py
+++ b/src/connect/protocol_grpc/error_trailer.py
@@ -37,7 +37,7 @@ def grpc_error_to_trailer(trailer: Headers, error: ConnectError | None) -> None:
         trailer[GRPC_HEADER_STATUS] = "0"
         return
 
-    if not ConnectError.wire_error:
+    if not error.wire_error:
         trailer.update(exclude_protocol_headers(error.metadata))
 
     status = status_pb2.Status(
@@ -151,9 +151,6 @@ def decode_binary_header(data: str) -> bytes:
 
     Returns:
         bytes: The decoded binary data.
-
-    Raises:
-        binascii.Error: If the input is not correctly base64-encoded.
 
     """
     if len(data) % 4:

--- a/src/connect/protocol_grpc/grpc_handler.py
+++ b/src/connect/protocol_grpc/grpc_handler.py
@@ -26,6 +26,7 @@ from connect.protocol_grpc.constants import (
     GRPC_HEADER_ACCEPT_COMPRESSION,
     GRPC_HEADER_COMPRESSION,
     GRPC_HEADER_TIMEOUT,
+    GRPC_TIMEOUT_MAX_DURATION,
     MAX_HOURS,
     RE_TIMEOUT,
     UNIT_TO_SECONDS,
@@ -145,7 +146,7 @@ class GRPCHandler(ProtocolHandler):
         protocol_name = PROTOCOL_GRPC if not self.web else PROTOCOL_GRPC + "-web"
 
         peer = Peer(
-            address=Address(host=request.client.host, port=request.client.port) if request.client else request.client,
+            address=Address(host=request.client.host, port=request.client.port) if request.client else None,
             protocol=protocol_name,
             query=request.query_params,
         )
@@ -267,7 +268,7 @@ class GRPCHandlerConn(StreamingHandlerConn):
 
         num_str, unit = m.groups()
         num = int(num_str)
-        if num > 99_999_999:
+        if num > GRPC_TIMEOUT_MAX_DURATION:
             raise ConnectError(f"protocol error: timeout {timeout!r} is too long")
 
         if unit == "H" and num > MAX_HOURS:


### PR DESCRIPTION
This pull request includes updates to improve error handling, enhance timeout management, and refine the handling of peer and response metadata across multiple files in the `connect` protocol.

### Error Handling Improvements:
* [`src/connect/protocol_grpc/error_trailer.py`](diffhunk://#diff-cb51eec20c5f1fb5ea451acfb34bac45f4bad36313f4c836b43da86e94002182L40-R40): Fixed a bug in `grpc_error_to_trailer` by correcting the reference to `error.wire_error` instead of `ConnectError.wire_error`.
* [`src/connect/protocol_grpc/grpc_client.py`](diffhunk://#diff-ed1dcf467a8e6127ca12df055a9254040726739e72fec615e5d67f50070babc2L297-R299): Ensured that `server_error.metadata` uses a copy of `response_trailers` to prevent unintended modifications.

### Timeout Management Enhancements:
* [`src/connect/protocol_grpc/constants.py`](diffhunk://#diff-663f420921d9ce0c5fc922daa88891b5fc9f9e4257dea49cee7c4683d4cf3706L24-R25): Introduced `GRPC_TIMEOUT_MAX_VALUE` and `GRPC_TIMEOUT_MAX_DURATION` constants for better timeout management. Updated the default gRPC user agent to include the Python version. [[1]](diffhunk://#diff-663f420921d9ce0c5fc922daa88891b5fc9f9e4257dea49cee7c4683d4cf3706L24-R25) [[2]](diffhunk://#diff-663f420921d9ce0c5fc922daa88891b5fc9f9e4257dea49cee7c4683d4cf3706R38-R39)
* [`src/connect/protocol_grpc/grpc_handler.py`](diffhunk://#diff-a905f9b73b7cf20bacfff120546af795c8e1d48cb49ec1318e0cbe785fde43a9L270-R271): Replaced hardcoded timeout validation with `GRPC_TIMEOUT_MAX_DURATION` for consistency.

### Peer and Metadata Handling:
* `src/connect/protocol_connect/connect_handler.py` and `src/connect/protocol_grpc/grpc_handler.py`: Updated peer initialization to set `address` to `None` when `request.client` is unavailable, ensuring consistent behavior. [[1]](diffhunk://#diff-3e3bf7c12ed7bb1b239b70a4aca1803275e8d6fc4196bbcc22d6f18b64621534L210-R210) [[2]](diffhunk://#diff-a905f9b73b7cf20bacfff120546af795c8e1d48cb49ec1318e0cbe785fde43a9L148-R149)
* [`src/connect/protocol_grpc/grpc_client.py`](diffhunk://#diff-ed1dcf467a8e6127ca12df055a9254040726739e72fec615e5d67f50070babc2R388-R391): Implemented proper cleanup of tasks in `async def send` to avoid resource leaks.