### PR TITLE
examples: add idempotency_level

### DIFF
--- a/examples/proto/connectrpc/eliza/v1/v1connect/eliza_connect_pb2.py
+++ b/examples/proto/connectrpc/eliza/v1/v1connect/eliza_connect_pb2.py
@@ -7,12 +7,20 @@
 import abc
 from enum import Enum
 
-from connect.client import Client
-from connect.connect import StreamRequest, StreamResponse, UnaryRequest, UnaryResponse
+from connect import (
+    Client,
+    ClientOptions,
+    ConnectOptions,
+    Handler,
+    HandlerContext,
+    IdempotencyLevel,
+    StreamRequest,
+    StreamResponse,
+    UnaryRequest,
+    UnaryResponse,
+)
 from connect.connection_pool import AsyncConnectionPool
-from connect.handler import ClientStreamHandler, Handler, ServerStreamHandler, UnaryHandler, BidiStreamHandler
-from connect.handler_context import HandlerContext
-from connect.options import ClientOptions, ConnectOptions
+from connect.handler import BidiStreamHandler, ClientStreamHandler, ServerStreamHandler, UnaryHandler
 from google.protobuf.descriptor import MethodDescriptor, ServiceDescriptor
 
 from .. import eliza_pb2
@@ -92,7 +100,7 @@ def create_ElizaService_handlers(service: ElizaServiceHandler, options: ConnectO
             unary=service.Say,
             input=SayRequest,
             output=SayResponse,
-            options=options,
+            options=ConnectOptions(idempotency_level=IdempotencyLevel.NO_SIDE_EFFECTS).merge(options),
         ),
         BidiStreamHandler(
             procedure=ElizaServiceProcedures.Converse.value,


### PR DESCRIPTION
This pull request introduces an enhancement to the `ElizaService` handlers in the `examples/proto/connectrpc/eliza/v1/v1connect/eliza_connect_pb2.py` file, focusing on improving idempotency handling for unary requests. Additionally, it includes the import of a new module to support this functionality.

Enhancements to idempotency handling:

* [`examples/proto/connectrpc/eliza/v1/v1connect/eliza_connect_pb2.py`](diffhunk://#diff-d44ae2a060c5c023ff457f8155fe5db8d97b4f665fd983585d7b79ae86c7481fL95-R96): Updated the `create_ElizaService_handlers` function to set the `idempotency_level` to `IdempotencyLevel.NO_SIDE_EFFECTS` for unary requests by merging this option with the existing `options` parameter.

Added module import:

* [`examples/proto/connectrpc/eliza/v1/v1connect/eliza_connect_pb2.py`](diffhunk://#diff-d44ae2a060c5c023ff457f8155fe5db8d97b4f665fd983585d7b79ae86c7481fR10): Imported `IdempotencyLevel` from the `connect` module to enable the new idempotency configuration.