### PR TITLE
conformance: handle known flaky "Timeouts" test.

### DIFF
--- a/.github/workflows/conformance.yaml
+++ b/.github/workflows/conformance.yaml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Run the connectconformance for server
         run: |
-          connectconformance --trace --vv --conf ./server_config.yaml --mode server -- uv run python server_runner.py
+          connectconformance --trace --vv --conf ./server_config.yaml --mode server --known-flaky @./server_known_flaky.yaml -- uv run python server_runner.py
 
   client:
     runs-on: ubuntu-2404-4-cores

--- a/conformance/server_known_flaky.yaml
+++ b/conformance/server_known_flaky.yaml
@@ -1,0 +1,1 @@
+Timeouts/**


### PR DESCRIPTION
This pull request updates the conformance testing workflow by introducing a mechanism to handle known flaky tests and modifying the configuration accordingly.

Updates to conformance testing:

* [`.github/workflows/conformance.yaml`](diffhunk://#diff-7bfd467904d753bc34e8f91ffbb8165dc048bbe3610af168c600072d0ec473c0L58-R58): Updated the `Run the connectconformance for server` step to include a `--known-flaky` flag pointing to `server_known_flaky.yaml`, allowing the workflow to account for known flaky tests.
* [`conformance/server_known_flaky.yaml`](diffhunk://#diff-71c8d4715571fe14890ca721c64c7e32c718eb9e4e772a471eea39c8f6e3e65fR1): Added a new entry `Timeouts/**` to specify tests that are known to be flaky.